### PR TITLE
Add SCHEDULE_EXACT_ALARM permission

### DIFF
--- a/android/privapp-permissions-opencyvis.xml
+++ b/android/privapp-permissions-opencyvis.xml
@@ -6,5 +6,6 @@
         <permission name="android.permission.CAPTURE_SECURE_VIDEO_OUTPUT"/>
         <permission name="android.permission.INTERNAL_SYSTEM_WINDOW"/>
         <permission name="android.permission.MANAGE_ACTIVITY_TASKS"/>
+        <permission name="android.permission.SCHEDULE_EXACT_ALARM"/>
     </privapp-permissions>
 </permissions>


### PR DESCRIPTION
Restart stuck at logo.  
Log analysis shows that the OpenCyvis app crashed SystemServer.  
The same fatal error keeps appearing in the logs:  
FATAL EXCEPTION IN SYSTEM PROCESS: main  

java.lang.IllegalStateException:  
Signature|privileged permissions not in privileged permission allowlist: {  
  ai.opencyvis (/system/priv-app/OpenCyvis):  
  android.permission.SCHEDULE_EXACT_ALARM  
}  

The APK’s source manifest has this permission, but the XML does not, so it needs to be added.