### PR TITLE
fix: support Shizuku backend selection and improve dialog contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ OpenCyvis is the open-source alternative: you see every line of code, you pick t
 For most users. No custom ROM, no root, no computer.
 
 1. Download and install the APK
-2. Open the app, follow the setup wizard to complete ADB wireless pairing
+2. Open the app and choose ADB wireless pairing or Shizuku as the privilege backend
 3. Choose your LLM backend (cloud or local), start using
 
-The entire pairing process completes on-device. Supports Android 11+.
+The built-in ADB wireless pairing flow completes entirely on-device. Alternatively, if [Shizuku](https://shizuku.rikka.app/) is already running, grant OpenCyvis access once and no wireless debugging or pairing is needed. Supports Android 11+.
 
-> **Pairing tips**
+> **ADB wireless pairing tips**
 > - The wizard sends you to **Wireless debugging → Pair device with pairing code**. Once you see the 6-digit code, **pull down the notification shade** and type the code straight into the OpenCyvis notification — no need to switch back to the app.
 > - Some vendor ROMs (ColorOS / OnePlus, MIUI, …) freeze apps once they go to the background. If the system asks you to **allow background activity / ignore battery optimization** during pairing, choose **Allow** for a smoother experience.
 > - If you don't see the notification with the input field, just pull down the shade once to find it.
@@ -101,7 +101,7 @@ Flash an AOSP system image. The app runs as a system application with full platf
 
 ### How they relate
 
-Same AI engine, same LLM backends, same UI, same capabilities. The only difference is how the app obtains system permissions. Standard mode uses ADB shell privileges; System App mode uses platform signing. For everyday tasks, you won't notice the difference.
+Same AI engine, same LLM backends, same UI, same capabilities. The only difference is how the app obtains system permissions. Standard mode uses ADB shell or Shizuku privileges; System App mode uses platform signing. For everyday tasks, you won't notice the difference.
 
 ---
 
@@ -186,7 +186,7 @@ Both install modes share all upper-layer code. The difference is only in the pri
 
 | | SystemBackend | RemoteBackend |
 |---|---|---|
-| Privilege source | Platform signing (uid system) | ADB shell (uid 2000) |
+| Privilege source | Platform signing (uid system) | ADB shell or Shizuku |
 | Input injection | InputManager reflection | AIDL proxy to PrivilegedService |
 | Screenshot | SurfaceControl.screenshot() | ImageReader from VD Surface |
 | VD task management | ActivityTaskManager reflection | PrivilegedService proxy |
@@ -224,11 +224,11 @@ Two APKs are available on the [Releases](https://github.com/opencyvis/opencyvis-
 ### Standard Mode (recommended)
 
 1. Download `opencyvis-standard-release.apk` and install
-2. Open the app, follow the setup wizard to complete wireless pairing
+2. Open the app and choose ADB wireless pairing or Shizuku
 3. Configure your LLM provider in Settings
 4. Start sending tasks
 
-No root, no computer, no custom ROM required. During pairing, type the 6-digit code into the OpenCyvis notification (pull down the shade), and allow background activity if your ROM prompts for it.
+Use the built-in ADB wireless pairing flow by entering the 6-digit code in the OpenCyvis notification and allowing background activity if your ROM prompts for it. Alternatively, if Shizuku is already running, simply grant OpenCyvis access—no wireless pairing is required.
 
 ### System App Mode
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -83,12 +83,12 @@ OpenCyvis 是开源替代方案：你能看到每一行代码，你来选 AI 模
 适合大多数用户。不需要刷机，不需要 Root，不需要连接电脑。
 
 1. 下载 APK，正常安装
-2. 打开 App，设置向导引导完成 ADB 无线配对
+2. 打开 App，选择 ADB 无线配对或 Shizuku 作为权限后端
 3. 选择 LLM 后端（云端或本地），开始使用
 
-整个配对过程在手机上独立完成。支持 Android 11 及以上版本。
+内置的 ADB 无线配对可完全在手机上完成。或者，如果设备上已运行 [Shizuku](https://shizuku.rikka.app/)，授予 OpenCyvis 权限一次即可使用，无需开启无线调试或进行无线配对。支持 Android 11 及以上版本。
 
-> **配对小贴士**
+> **ADB 无线配对小贴士**
 > - 设置向导会引导你打开系统的「无线调试 → 使用配对码配对」。看到 6 位配对码后，**下拉通知栏**，在 OpenCyvis 的通知里直接输入配对码即可——不用切回 App。
 > - 部分国产 ROM（ColorOS / 一加、MIUI 等）会在切到后台后冻结应用。配对时如果系统弹出「允许后台运行 / 忽略电池优化」的提示，请选择**允许**，配对会更顺畅。
 > - 如果没看到带输入框的通知，手动下拉一次通知栏即可找到。
@@ -101,7 +101,7 @@ OpenCyvis 是开源替代方案：你能看到每一行代码，你来选 AI 模
 
 ### 两种模式的关系
 
-核心 AI 引擎、LLM 后端、UI 界面、操作能力——两种模式完全一样。差异仅在底层：系统 App 直接调用系统 API，标准模式通过 ADB shell 权限获得同等能力。绝大多数日常场景下，用户感受不到区别。
+核心 AI 引擎、LLM 后端、UI 界面、操作能力——两种模式完全一样。差异仅在底层：系统 App 直接调用系统 API，标准模式通过 ADB shell 或 Shizuku 权限获得同等能力。绝大多数日常场景下，用户感受不到区别。
 
 ---
 
@@ -186,7 +186,7 @@ OpenCyvis 不绑定模型。用户自行配置 LLM 后端。
 
 | | SystemBackend | RemoteBackend |
 |---|---|---|
-| 权限来源 | 平台签名（uid system） | ADB shell（uid 2000） |
+| 权限来源 | 平台签名（uid system） | ADB shell 或 Shizuku |
 | 输入注入 | InputManager 反射 | AIDL 代理到 PrivilegedService |
 | 截屏 | SurfaceControl.screenshot() | ImageReader 从 VD Surface 读取 |
 | VD 任务管理 | ActivityTaskManager 反射 | PrivilegedService 代理 |
@@ -224,11 +224,11 @@ OpenCyvis 不绑定模型。用户自行配置 LLM 后端。
 ### 标准模式（推荐）
 
 1. 下载 `opencyvis-standard-release.apk` 并安装
-2. 打开 App，跟随设置向导完成无线配对
+2. 打开 App，选择 ADB 无线配对或 Shizuku
 3. 在设置中配置 LLM Provider
 4. 开始发送任务
 
-不需要 Root，不需要电脑，不需要刷机。配对时下拉通知栏，在 OpenCyvis 通知里输入 6 位配对码；若 ROM 提示允许后台运行，请选择允许。
+使用内置 ADB 无线配对时，下拉通知栏并在 OpenCyvis 通知里输入 6 位配对码；若 ROM 提示允许后台运行，请选择允许。或者，设备上已运行 Shizuku 时，只需授予 OpenCyvis 权限，无需无线配对。
 
 ### 系统 App 模式
 

--- a/android/app/src/main/java/ai/opencyvis/AgentService.kt
+++ b/android/app/src/main/java/ai/opencyvis/AgentService.kt
@@ -128,9 +128,13 @@ class AgentService : Service() {
 
     /** Update the backend after pairing/reconnection (called by AdbPairingService). */
     fun updateBackend(newBackend: PrivilegeBackend) {
+        val previousBackend = backend
         backend = newBackend
         ScreenCapture.backend = newBackend
         observeConnectorState(newBackend)
+        if (previousBackend !== newBackend) {
+            previousBackend?.destroy()
+        }
         Log.i(TAG, "Backend updated: ${newBackend.capabilities.name}")
     }
     private var stateObserverJob: Job? = null
@@ -250,10 +254,12 @@ class AgentService : Service() {
                             Log.w(TAG, "Backend disconnected while idle")
                         }
 
-                        // Attempt auto-reconnect
+                        // Shizuku is independent of wireless debugging. Only the direct
+                        // ADB connector should use adb_wifi_enabled as a retry condition.
                         val wirelessOn = SetupStateDetector.isWirelessDebuggingEnabled(this@AgentService)
-                        if (wirelessOn) {
-                            Log.i(TAG, "Wireless debugging still on, attempting auto-reconnect...")
+                        val canRetry = b.connector.name == "shizuku" || wirelessOn
+                        if (canRetry) {
+                            Log.i(TAG, "Attempting ${b.connector.name} backend reconnect...")
                             var reconnected = false
                             for (attempt in 1..5) {
                                 delay(3000L * attempt)
@@ -269,7 +275,7 @@ class AgentService : Service() {
                                 ScreenCapture.backend = SystemBackend()
                             }
                         } else {
-                            Log.i(TAG, "Wireless debugging is off, clearing backend")
+                            Log.i(TAG, "Wireless debugging is off for ADB backend, clearing backend")
                             backend = null
                             ScreenCapture.backend = SystemBackend()
                         }

--- a/android/app/src/main/java/ai/opencyvis/SettingsFragment.kt
+++ b/android/app/src/main/java/ai/opencyvis/SettingsFragment.kt
@@ -719,8 +719,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val backendName = App.agentService?.activeBackendName
         statusPref.summary = when (backendName) {
             "system"     -> "System App (full capabilities)"
-            "shizuku"    -> "Shizuku (shell permissions)"
-            "adb-direct" -> "ADB Direct (shell permissions)"
+            "shizuku"    -> "Shizuku — tap to change"
+            "adb-direct" -> "ADB Direct — tap to change"
             null, "none" -> "Not connected — tap to set up"
             else         -> backendName
         }
@@ -735,10 +735,19 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         statusPref.setOnPreferenceClickListener {
             val name = App.agentService?.activeBackendName
-            if (name == null || name == "none") {
-                startActivity(android.content.Intent(requireContext(),
-                    ai.opencyvis.backend.SetupActivity::class.java))
+            if (name == "system") {
+                Toast.makeText(requireContext(), "System backend is fixed for this build", Toast.LENGTH_SHORT).show()
+                return@setOnPreferenceClickListener true
             }
+            val intent = android.content.Intent(requireContext(),
+                ai.opencyvis.backend.SetupActivity::class.java)
+            if (name != null && name != "none" && name != "system") {
+                intent.putExtra(
+                    ai.opencyvis.backend.SetupActivity.EXTRA_FORCE_METHOD_CHOOSER,
+                    true
+                )
+            }
+            startActivity(intent)
             true
         }
 

--- a/android/app/src/main/java/ai/opencyvis/backend/BackendDetector.kt
+++ b/android/app/src/main/java/ai/opencyvis/backend/BackendDetector.kt
@@ -23,8 +23,13 @@ object BackendDetector {
             return DetectionResult.Ready(SystemBackend())
         }
 
-        // Try connectors in priority order
+        // Shizuku is the preferred standard-app backend. A running Shizuku that has
+        // not been authorized yet must lead to the permission UI, not wireless ADB.
         val connectors = buildConnectorList(context)
+        if (ShizukuConnector.status() == ShizukuStatus.PERMISSION_REQUIRED) {
+            Log.i(TAG, "Shizuku is running and needs app permission")
+            return DetectionResult.SetupRequired(connectors)
+        }
 
         for (connector in connectors) {
             if (!connector.isAvailable()) continue

--- a/android/app/src/main/java/ai/opencyvis/backend/SetupActivity.kt
+++ b/android/app/src/main/java/ai/opencyvis/backend/SetupActivity.kt
@@ -28,6 +28,8 @@ class SetupActivity : AppCompatActivity() {
 
     companion object {
         const val RESULT_BACKEND_READY = 100
+        const val EXTRA_FORCE_METHOD_CHOOSER = "force_method_chooser"
+        private const val SHIZUKU_PERMISSION_REQUEST_CODE = 41
     }
 
     private enum class SetupState {
@@ -61,7 +63,33 @@ class SetupActivity : AppCompatActivity() {
     private var privilegedService: IPrivilegedService? = null
     private var resumeAfterCreate = false
     private var pairingPortJob: Job? = null
+    private var shizukuConnectJob: Job? = null
     private var requestedBatteryExemption = false
+    private var preferWirelessAdb = false
+    private var forceMethodChooser = false
+
+    private val shizukuBinderReceivedListener = rikka.shizuku.Shizuku.OnBinderReceivedListener {
+        if (!forceMethodChooser &&
+            !preferWirelessAdb &&
+            currentState != SetupState.SHIZUKU_CHECK &&
+            currentState != SetupState.CONNECTING &&
+            currentState != SetupState.ADB_PAIR &&
+            currentState != SetupState.CONNECTED
+        ) {
+            startPreferredSetupFlow()
+        }
+    }
+
+    private val shizukuPermissionResultListener =
+        rikka.shizuku.Shizuku.OnRequestPermissionResultListener { requestCode, grantResult ->
+            if (requestCode != SHIZUKU_PERMISSION_REQUEST_CODE) return@OnRequestPermissionResultListener
+            if (grantResult == PackageManager.PERMISSION_GRANTED) {
+                forceMethodChooser = false
+                updateUi(SetupState.SHIZUKU_CHECK)
+            } else {
+                showShizukuPermissionDenied()
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -93,12 +121,38 @@ class SetupActivity : AppCompatActivity() {
         numberPad.onDigit = { digit -> otpBox.appendDigit(digit) }
         numberPad.onBackspace = { otpBox.deleteDigit() }
 
+        rikka.shizuku.Shizuku.addBinderReceivedListener(shizukuBinderReceivedListener)
+        rikka.shizuku.Shizuku.addRequestPermissionResultListener(shizukuPermissionResultListener)
+
         // Persistent observer: mDNS discovers the pairing service port the moment the
         // user opens "Pair device with pairing code" in Settings. That is the signal
         // that the user is ready to type the code — auto-advance to the code-entry step
         // (step 3) regardless of which pre-pairing step we're currently showing.
         observePairingPort()
 
+        forceMethodChooser = intent.getBooleanExtra(EXTRA_FORCE_METHOD_CHOOSER, false)
+        if (forceMethodChooser) {
+            updateUi(SetupState.CHOOSE_METHOD)
+        } else {
+            startPreferredSetupFlow()
+        }
+        resumeAfterCreate = true
+    }
+
+    /** Prefer a running Shizuku before evaluating any wireless ADB prerequisites. */
+    private fun startPreferredSetupFlow() {
+        if (preferWirelessAdb) {
+            startAdbSetupFlow()
+            return
+        }
+        when (ShizukuConnector.status()) {
+            ShizukuStatus.READY -> updateUi(SetupState.SHIZUKU_CHECK)
+            ShizukuStatus.PERMISSION_REQUIRED -> updateUi(SetupState.SHIZUKU_PERMISSION)
+            ShizukuStatus.UNAVAILABLE -> startAdbSetupFlow()
+        }
+    }
+
+    private fun startAdbSetupFlow() {
         val detected = SetupStateDetector.detect(this, false)
         Log.i("SetupActivity", "onCreate: detected=$detected taskId=$taskId")
         val startState = when (detected) {
@@ -119,7 +173,6 @@ class SetupActivity : AppCompatActivity() {
         }
         Log.i("SetupActivity", "onCreate: startState=$startState")
         updateUi(startState)
-        resumeAfterCreate = true
     }
 
     override fun onResume() {
@@ -132,6 +185,13 @@ class SetupActivity : AppCompatActivity() {
         // Guard: don't re-detect if user is mid-code-entry in split-screen
         if (isInMultiWindowMode && currentState == SetupState.ADB_PAIR) {
             Log.i("SetupActivity", "onResume: skipping detection in multi-window ADB_PAIR")
+            return
+        }
+
+        if (forceMethodChooser && currentState == SetupState.CHOOSE_METHOD) return
+
+        if (!preferWirelessAdb && ShizukuConnector.status() != ShizukuStatus.UNAVAILABLE) {
+            startPreferredSetupFlow()
             return
         }
 
@@ -178,24 +238,18 @@ class SetupActivity : AppCompatActivity() {
 
         when (state) {
             SetupState.CHOOSE_METHOD -> {
-                // Check if Shizuku is installed — if so, offer it as secondary option
-                val shizukuAvailable = try {
-                    ShizukuConnector(this).isAvailable()
-                } catch (_: Exception) { false }
-
-                if (shizukuAvailable) {
+                val shizukuStatus = ShizukuConnector.status()
+                if (shizukuStatus != ShizukuStatus.UNAVAILABLE) {
                     // Shizuku detected — offer both options
-                    titleView.text = "Setup"
-                    descView.text = "OpenCyvis needs permissions to control the device.\n\n" +
-                        "Shizuku is detected on your device — you can use it for a quick setup, " +
-                        "or use the built-in Wireless ADB method (no extra apps needed)."
+                    titleView.text = "Choose Backend"
+                    descView.text = "Shizuku is available. Choose which privilege backend OpenCyvis should use."
                     actionButton.text = "Use Shizuku"
                     secondaryButton.text = "Use Wireless ADB"
                     secondaryButton.visibility = View.VISIBLE
                 } else {
-                    // No Shizuku — go directly to wireless ADB flow
-                    updateUi(SetupState.ADB_CHECK_OS)
-                    return
+                    titleView.text = "Choose Backend"
+                    descView.text = "Shizuku is not running. Wireless ADB is the available standard-app backend."
+                    actionButton.text = "Use Wireless ADB"
                 }
             }
             SetupState.NEED_WIFI -> {
@@ -215,6 +269,8 @@ class SetupActivity : AppCompatActivity() {
                 titleView.text = "Shizuku Permission"
                 descView.text = "Shizuku is running. Grant permission to OpenCyvis to continue."
                 actionButton.text = "Grant Permission"
+                secondaryButton.text = "Use Wireless ADB"
+                secondaryButton.visibility = View.VISIBLE
             }
             SetupState.ADB_CHECK_OS -> {
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
@@ -312,7 +368,17 @@ class SetupActivity : AppCompatActivity() {
 
     private fun onActionClick() {
         when (currentState) {
-            SetupState.CHOOSE_METHOD -> updateUi(SetupState.SHIZUKU_CHECK)
+            SetupState.CHOOSE_METHOD -> {
+                forceMethodChooser = false
+                when (ShizukuConnector.status()) {
+                    ShizukuStatus.READY -> updateUi(SetupState.SHIZUKU_CHECK)
+                    ShizukuStatus.PERMISSION_REQUIRED -> updateUi(SetupState.SHIZUKU_PERMISSION)
+                    ShizukuStatus.UNAVAILABLE -> {
+                        preferWirelessAdb = true
+                        startAdbSetupFlow()
+                    }
+                }
+            }
             SetupState.NEED_WIFI -> {
                 // Re-check WiFi
                 if (SetupStateDetector.hasWifi(this)) {
@@ -351,7 +417,15 @@ class SetupActivity : AppCompatActivity() {
 
     private fun onSecondaryClick() {
         when (currentState) {
-            SetupState.CHOOSE_METHOD -> updateUi(SetupState.ADB_CHECK_OS)
+            SetupState.CHOOSE_METHOD -> {
+                forceMethodChooser = false
+                preferWirelessAdb = true
+                updateUi(SetupState.ADB_CHECK_OS)
+            }
+            SetupState.SHIZUKU_PERMISSION -> {
+                preferWirelessAdb = true
+                startAdbSetupFlow()
+            }
             SetupState.ADB_ENABLE_DEV -> updateUi(SetupState.ADB_ENABLE_WIRELESS)
             SetupState.ADB_ENABLE_WIRELESS -> {
                 // "Enter Code Manually"
@@ -440,7 +514,8 @@ class SetupActivity : AppCompatActivity() {
     }
 
     private fun checkShizuku() {
-        scope.launch {
+        if (shizukuConnectJob?.isActive == true) return
+        shizukuConnectJob = scope.launch {
             try {
                 val connector = ShizukuConnector(this@SetupActivity)
                 if (connector.isAvailable()) {
@@ -452,6 +527,7 @@ class SetupActivity : AppCompatActivity() {
                         }
                     }
                     if (result is ConnectionState.Connected) {
+                        registerConnectedBackend(connector, result.serviceBinder)
                         updateUi(SetupState.CONNECTED)
                     } else {
                         updateUi(SetupState.FAILED)
@@ -465,35 +541,29 @@ class SetupActivity : AppCompatActivity() {
                     if (shizukuRunning) {
                         updateUi(SetupState.SHIZUKU_PERMISSION)
                     } else {
-                        descView.text = "Shizuku is not installed or not running.\n\n" +
-                            "Install Shizuku from the Play Store and start it, then try again.\n\n" +
-                            "Or use Wireless ADB instead."
-                        actionButton.text = "Retry"
-                        actionButton.isEnabled = true
-                        secondaryButton.text = "Use Wireless ADB"
-                        secondaryButton.visibility = View.VISIBLE
-                        secondaryButton.setOnClickListener { updateUi(SetupState.ADB_CHECK_OS) }
+                        startAdbSetupFlow()
                     }
                 }
             } catch (e: Exception) {
+                updateUi(SetupState.FAILED)
                 descView.text = "Error checking Shizuku: ${e.message}"
-                actionButton.text = "Retry"
-                actionButton.isEnabled = true
+            } finally {
+                shizukuConnectJob = null
             }
         }
     }
 
     private fun requestShizukuPermission() {
         try {
-            rikka.shizuku.Shizuku.requestPermission(0)
-            // Permission result is async -- re-check after a delay
-            scope.launch {
-                kotlinx.coroutines.delay(2000)
-                checkShizuku()
-            }
+            rikka.shizuku.Shizuku.requestPermission(SHIZUKU_PERMISSION_REQUEST_CODE)
         } catch (e: Exception) {
             Toast.makeText(this, "Failed to request permission: ${e.message}", Toast.LENGTH_SHORT).show()
         }
+    }
+
+    private fun showShizukuPermissionDenied() {
+        updateUi(SetupState.SHIZUKU_PERMISSION)
+        descView.text = "Shizuku permission was denied. Grant permission to use Shizuku, or continue with Wireless ADB."
     }
 
     /**
@@ -502,14 +572,14 @@ class SetupActivity : AppCompatActivity() {
      * activeBackendName == "none" after we finish and re-launches setup / re-runs the
      * reconnect flow. Mirrors AdbPairingService.connectAfterPairing().
      */
-    private fun registerConnectedBackend(connector: DirectConnector, binder: android.os.IBinder) {
+    private fun registerConnectedBackend(connector: ServiceConnector, binder: android.os.IBinder) {
         try {
             val svc = IPrivilegedService.Stub.asInterface(binder)
             privilegedService = svc
             val backend = RemoteBackend(connector, svc)
             ai.opencyvis.capture.ScreenCapture.backend = backend
             ai.opencyvis.App.agentService?.updateBackend(backend)
-            Log.i("SetupActivity", "Backend registered with AgentService after pairing")
+            Log.i("SetupActivity", "Backend registered with AgentService via ${connector.name}")
         } catch (e: Exception) {
             Log.e("SetupActivity", "Failed to register backend after pairing", e)
         }
@@ -667,8 +737,11 @@ class SetupActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        rikka.shizuku.Shizuku.removeBinderReceivedListener(shizukuBinderReceivedListener)
+        rikka.shizuku.Shizuku.removeRequestPermissionResultListener(shizukuPermissionResultListener)
         scope.cancel()
         pairingPortJob?.cancel()
+        shizukuConnectJob?.cancel()
         super.onDestroy()
     }
 }

--- a/android/app/src/main/java/ai/opencyvis/backend/ShizukuConnector.kt
+++ b/android/app/src/main/java/ai/opencyvis/backend/ShizukuConnector.kt
@@ -12,10 +12,30 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import rikka.shizuku.Shizuku
 
+enum class ShizukuStatus {
+    UNAVAILABLE,
+    PERMISSION_REQUIRED,
+    READY
+}
+
 class ShizukuConnector(private val context: Context) : ServiceConnector {
 
     companion object {
         private const val TAG = "ShizukuConnector"
+
+        fun status(): ShizukuStatus {
+            return try {
+                if (!Shizuku.pingBinder()) {
+                    ShizukuStatus.UNAVAILABLE
+                } else if (Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED) {
+                    ShizukuStatus.READY
+                } else {
+                    ShizukuStatus.PERMISSION_REQUIRED
+                }
+            } catch (_: Exception) {
+                ShizukuStatus.UNAVAILABLE
+            }
+        }
     }
 
     override val name = "shizuku"
@@ -26,6 +46,7 @@ class ShizukuConnector(private val context: Context) : ServiceConnector {
     private var reconnectAttempt = 0
     private val reconnectDelays = longArrayOf(2000, 4000, 8000, 15000, 30000)
     private var userServiceArgs: Shizuku.UserServiceArgs? = null
+    private var connectedBinder: IBinder? = null
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
@@ -33,8 +54,14 @@ class ShizukuConnector(private val context: Context) : ServiceConnector {
                 _state.value = ConnectionState.Failed("null binder")
                 return
             }
+            if (connectedBinder === binder && _state.value is ConnectionState.Connected) {
+                Log.d(TAG, "Ignoring duplicate onServiceConnected callback")
+                return
+            }
+            connectedBinder = binder
             binder.linkToDeath({
                 Log.w(TAG, "Remote process died")
+                connectedBinder = null
                 _state.value = ConnectionState.Disconnected
                 scheduleReconnect()
             }, 0)
@@ -45,6 +72,7 @@ class ShizukuConnector(private val context: Context) : ServiceConnector {
 
         override fun onServiceDisconnected(name: ComponentName?) {
             Log.w(TAG, "Disconnected — scheduling reconnect")
+            connectedBinder = null
             _state.value = ConnectionState.Disconnected
             scheduleReconnect()
         }
@@ -62,12 +90,14 @@ class ShizukuConnector(private val context: Context) : ServiceConnector {
     }
 
     override fun isAvailable(): Boolean {
-        return try {
-            Shizuku.pingBinder() && Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
-        } catch (_: Exception) { false }
+        return status() == ShizukuStatus.READY
     }
 
     override fun connect() {
+        if (!isAvailable()) {
+            _state.value = ConnectionState.Failed("Shizuku is unavailable or permission is not granted")
+            return
+        }
         _state.value = ConnectionState.Connecting
         try {
             val args = Shizuku.UserServiceArgs(
@@ -88,6 +118,7 @@ class ShizukuConnector(private val context: Context) : ServiceConnector {
                 Shizuku.unbindUserService(args, serviceConnection, false)
             }
         } catch (_: Exception) {}
+        connectedBinder = null
         _state.value = ConnectionState.Disconnected
     }
 }

--- a/android/app/src/main/java/ai/opencyvis/ui/ControlPanelActivity.kt
+++ b/android/app/src/main/java/ai/opencyvis/ui/ControlPanelActivity.kt
@@ -814,9 +814,12 @@ class ControlPanelActivity : AppCompatActivity() {
         if (service != null) {
             val backendName = service.activeBackendName
             if (backendName == null || backendName == "none") {
-                if (ai.opencyvis.backend.SetupStateDetector.isWirelessDebuggingEnabled(this)) {
+                val shizukuPresent =
+                    ai.opencyvis.backend.ShizukuConnector.status() !=
+                        ai.opencyvis.backend.ShizukuStatus.UNAVAILABLE
+                if (shizukuPresent || ai.opencyvis.backend.SetupStateDetector.isWirelessDebuggingEnabled(this)) {
                     scope.launch {
-                        Log.i(TAG, "No backend but wireless debugging is on, retrying...")
+                        Log.i(TAG, "A privilege backend is available, retrying detection...")
                         val success = service.retryBackendDetection()
                         if (success) {
                             Log.i(TAG, "Backend reconnected on resume")

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -28,4 +28,7 @@
     <color name="text_countdown">#9CC7FF</color>
     <color name="text_cycle">#94A3B8</color>
     <color name="text_on_bubble_user">#F0FFFFFF</color>
+
+    <!-- Dialog actions -->
+    <color name="dialog_action">#E8BE4D</color>
 </resources>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -7,15 +7,19 @@
         <item name="android:windowBackground">@color/surface</item>
         <item name="android:statusBarColor">@color/surface</item>
         <item name="android:navigationBarColor">@color/surface</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
     </style>
 
     <style name="Theme.OpenCyvis.Settings" parent="Theme.Material3.DayNight.NoActionBar">
-        <item name="colorPrimary">@color/surface_container</item>
+        <item name="colorPrimary">@color/dialog_action</item>
         <item name="colorOnPrimary">@color/on_surface</item>
         <item name="colorAccent">@color/color_accent</item>
         <item name="android:windowBackground">@color/surface</item>
         <item name="android:statusBarColor">@color/surface</item>
         <item name="android:navigationBarColor">@color/surface</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
     </style>
 
@@ -26,6 +30,8 @@
         <item name="android:windowBackground">@color/surface</item>
         <item name="android:statusBarColor">@color/surface</item>
         <item name="android:navigationBarColor">@color/surface</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
     </style>
 
     <style name="Theme.OpenCyvis.Dialog" parent="Theme.Material3.DayNight.Dialog">
@@ -35,5 +41,7 @@
         <item name="android:windowBackground">@color/surface</item>
         <item name="android:statusBarColor">@color/surface</item>
         <item name="android:navigationBarColor">@color/surface</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -31,6 +31,9 @@
     <color name="text_cycle">#64748B</color>
     <color name="text_on_bubble_user">#F0FFFFFF</color>
 
+    <!-- Dialog actions -->
+    <color name="dialog_action">#7A5B00</color>
+
     <!-- Brand / Semantic colors (same in both themes) -->
     <color name="color_accent">#FFCBA135</color>
     <color name="color_success">#4ADE80</color>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -5,13 +5,17 @@
         <item name="colorOnPrimary">@color/on_surface</item>
         <item name="colorAccent">@color/color_accent</item>
         <item name="android:windowBackground">@color/surface</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
     </style>
 
     <style name="Theme.OpenCyvis.Settings" parent="Theme.Material3.DayNight.NoActionBar">
-        <item name="colorPrimary">@color/surface_container</item>
+        <item name="colorPrimary">@color/dialog_action</item>
         <item name="colorOnPrimary">@color/on_surface</item>
         <item name="colorAccent">@color/color_accent</item>
         <item name="android:windowBackground">@color/surface</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
     </style>
 
@@ -20,6 +24,8 @@
         <item name="colorOnPrimary">@color/on_surface</item>
         <item name="colorAccent">@color/color_accent</item>
         <item name="android:windowBackground">@color/surface</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
     </style>
 
     <style name="Theme.OpenCyvis.Dialog" parent="Theme.Material3.DayNight.Dialog">
@@ -27,6 +33,14 @@
         <item name="colorOnPrimary">@color/on_surface</item>
         <item name="colorAccent">@color/color_accent</item>
         <item name="android:windowBackground">@color/surface</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
+        <item name="android:alertDialogTheme">@style/ThemeOverlay.OpenCyvis.AlertDialog</item>
+    </style>
+
+    <style name="ThemeOverlay.OpenCyvis.AlertDialog" parent="ThemeOverlay.Material3.Dialog.Alert">
+        <item name="colorPrimary">@color/dialog_action</item>
+        <item name="colorAccent">@color/dialog_action</item>
+        <item name="android:colorAccent">@color/dialog_action</item>
     </style>
 
     <!-- Button style that respects android:background drawable -->

--- a/android/app/src/main/res/xml/settings_root.xml
+++ b/android/app/src/main/res/xml/settings_root.xml
@@ -220,7 +220,7 @@
         <Preference
             android:key="backend_status"
             android:title="Active Backend"
-            android:selectable="false"
+            android:selectable="true"
             android:summary="Detecting..." />
 
         <Preference


### PR DESCRIPTION
## Summary

- prefer a running Shizuku backend and handle its permission flow without requiring wireless ADB
- allow users to inspect and switch the active standard-app backend
- document Shizuku alongside wireless ADB in both READMEs
- improve AlertDialog action contrast in light and dark themes

## Testing

- `./gradlew -Dorg.gradle.java.home=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home :app:assembleStandardDebug`
- `git diff --check`
- manually verified dialog actions in light and dark modes on Android 16